### PR TITLE
isBehaviour eingefügt

### DIFF
--- a/FHEM/lib/HM485/ConfigurationManager.pm
+++ b/FHEM/lib/HM485/ConfigurationManager.pm
@@ -236,8 +236,12 @@ sub getConfigSettings($) {
 				 	$deviceKey . '/paramset'
 				);
 			} else {
+				my $extension = HM485::Device::isBehaviour($hash) ? 
+						'/subconfig/paramset/hmw_io_ch_master' :
+						'/paramset/master';
+												   
 				$configSettings = HM485::Device::getValueFromDefinitions(
-				 	$deviceKey . '/channels/' . $chType .'/paramset/master'
+				 	$deviceKey . '/channels/' . $chType . $extension
 				);
 			}
 
@@ -293,8 +297,10 @@ sub convertSettingsToEepromData($$) {
 	if ($chNr > 0) { #im channel 0 gibt es nur address index kein address_start oder address_step
 		my $deviceKey    = HM485::Device::getDeviceKeyFromHash($hash);
 		my $chType       = HM485::Device::getChannelType($deviceKey, $chNr);
+		my $extension	 = HM485::Device::isBehaviour($hash) ? 
+						   '/subconfig/paramset/hmw_io_ch_master' : '/paramset/master';
 		my $masterConfig = HM485::Device::getValueFromDefinitions(
-			$deviceKey . '/channels/' . $chType . '/paramset/master'
+			$deviceKey . '/channels/' . $chType . $extension
 		);
 		#addres step in the other xml Version is serched in getPhysicalAddress
 		$adressStart = $masterConfig->{'address_start'} ? $masterConfig->{'address_start'} : 0;

--- a/FHEM/lib/HM485/Device.pm
+++ b/FHEM/lib/HM485/Device.pm
@@ -194,7 +194,34 @@ sub getModelList() {
 	return join(',', @modelList);
 }
 
+=head2 isBehaviour
+	Looks if channels behaviour is activ
+	@param	hash      hash of device addressed
+	
+	@return	boolean   behaviour enabled/disabled
+=cut
 
+sub isBehaviour($) {
+	my ($hash) = @_;
+	
+	my ($hmwId, $chNr)	= HM485::Util::getHmwIdAndChNrFromHash($hash);
+	my $deviceKey 		= getDeviceKeyFromHash($hash);
+	my $chType 			= getChannelType($deviceKey, $chNr);
+	my $config			= getValueFromDefinitions(
+		$deviceKey . '/channels/' .	$chType . '/paramset/master'
+	);
+	my $retVal;
+
+	if (ref($config->{parameter}{behaviour}) eq 'HASH') {
+		$retVal = HM485::ConfigurationManager::writeConfigParameter($hash,
+			$config->{parameter}{behaviour},
+			$config->{address_start},
+			$config->{address_step}
+		);
+	}
+
+	return $retVal->{value}
+}
 
 sub getBehaviour($) {
 	my ($hash) = @_;


### PR DESCRIPTION
 Nun kann man logging im IO12FM einschalten und
![home _sweet_home_-_2015-08-12_06 38 57](https://cloud.githubusercontent.com/assets/11468086/9216640/df720ea2-40bc-11e5-9e5e-aba964422e0d.png)
![home _sweet_home_-_2015-08-12_06 38 10](https://cloud.githubusercontent.com/assets/11468086/9216641/e575274e-40bc-11e5-992a-d4da339a7377.png)


pulstime und calibration erscheinen nur mehr bei analogen Eingängen im
IO12Sw14